### PR TITLE
feat: Add GitHub repository link to navigation bar

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -505,7 +505,7 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav">
+                <ul class="navbar-nav me-auto">
                     <li class="nav-item">
                         <a class="nav-link" href="/">Home</a>
                     </li>
@@ -515,6 +515,10 @@
                         </a>
                     </li>
                 </ul>
+                <a class="nav-link" href="https://github.com/kstonekuan/data-colada-tools" target="_blank" rel="noopener"
+                   aria-label="GitHub Repository">
+                    <i class="fab fa-github fa-lg"></i>
+                </a>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
This commit adds a link to the project's GitHub repository in the navigation bar. The link is represented by the GitHub logo from Font Awesome.

The link is added to the right side of the navigation bar.
