### PR TITLE
fix: Correct Font Awesome class for GitHub icon

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -505,7 +505,7 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav">
+                <ul class="navbar-nav me-auto">
                     <li class="nav-item">
                         <a class="nav-link" href="/">Home</a>
                     </li>
@@ -515,6 +515,10 @@
                         </a>
                     </li>
                 </ul>
+                <a class="nav-link" href="https://github.com/kstonekuan/data-colada-tools" target="_blank" rel="noopener"
+                   aria-label="GitHub Repository">
+                    <i class="fa-brands fa-github fa-lg"></i>
+                </a>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
The previous commit used an incorrect class for the Font Awesome GitHub icon, causing it not to render. This commit corrects the class from `fab fa-github` to `fa-brands fa-github`.